### PR TITLE
Fix: Mage Talent Required SilverTongue2

### DIFF
--- a/src/content/people/Natalie/_.coffee
+++ b/src/content/people/Natalie/_.coffee
@@ -45,7 +45,7 @@ Person.Natalie =
       doubledBy: 'Trust'
     Mage:
       description: 'Suffer one less damage each day in storms'
-      requiresOr: ['WellInformed', 'SilverTongue2']
+      requiresOr: ['WellInformed', 'SilverTongue']
 
     WinningSmile2:
       name: 'Winning Smile 2'


### PR DESCRIPTION
In the current build, Mage required Silver Tongue 2 instead of Silver Tongue 1 that lead up to it.